### PR TITLE
Move to blind quicker using MAX_BLINDS_ON_REMOTE

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,9 +6,9 @@ void buttonOnOff(int pin);
 
 void buttonOnOff(int pin1, int pin2);
 
-bool displayEquals22();
+bool displayEqualsLast();
 
-void markSynchronizedIfBlind20Reached();
+void markSynchronizedIfBlindReached();
 
 void onMqttMessage(int messageSize);
 
@@ -76,6 +76,7 @@ const int SEGMENT_INACTIVE_MVOLTS_THRESHOLD = 2000;
 
 // position
 int currentBlind = -1;
+const int MAX_BLINDS_ON_REMOTE = 22;
 
 // last <action> timestamps
 int lastOnlineMessageSentMillis = -DELAY_RECONNECTION_RETRIAL;
@@ -121,18 +122,18 @@ void loop() {
 void synchronize() {
   buttonOnOff(BUTTON_LEFT_PIN);
   delay(DELAY_BETWEEN_NAV_MS);
-  markSynchronizedIfBlind20Reached();
+  markSynchronizedIfBlindReached();
 }
 
 bool currentBlindKnown() { return currentBlind != -1; }
 
-void markSynchronizedIfBlind20Reached() {
-  if (displayEquals22()) {
-    currentBlind = 22;
+void markSynchronizedIfBlindReached() {
+  if (displayEqualsLast()) {
+    currentBlind = MAX_BLINDS_ON_REMOTE;
   }
 }
 
-bool displayEquals22() {
+bool displayEqualsLast() {
   int now = millis();
   while (millis() < now + DURATION_DISPLAY_DIGIT_PROBE_MS) {
     int milliVolts = analogReadMilliVolts(LED_LEFT_PIN);
@@ -273,6 +274,15 @@ void buttonOnOff(int pin1, int pin2) {
 
 void switchToBlindByNum(int num) {
   int delta = num - currentBlind;
+  int halfOfDistance = MAX_BLINDS_ON_REMOTE / 2;
+  if (abs(delta) > halfOfDistance) {
+    if (delta < 0) {
+      delta = delta + MAX_BLINDS_ON_REMOTE;
+    } else {
+      delta = delta - MAX_BLINDS_ON_REMOTE;
+    }
+  }
+
   if (delta != 0 && abs(delta) < 99) {
     for (int i = 0; i < abs(delta); i++) {
       if (i > 0) {


### PR DESCRIPTION
After adding MAX_BLINDS_ON_REMOTE I can now use very simple algorithm to move to a different number quicker.
Example:
    from 9th blind to 1st
        previously 8 times command "down"
        now 2 times command "up"

Also renamed 2 functions.

Long description:
In my setup I use different number of blinds. I only have 9 blinds for now so on my remote there is only 10 blind numbers allowed and I use 10th as blind to synchronize- if sent command to that number - nothing happens.
When making a copy of pwrozycki setup I discovered a couple of small improvements. This is a first one.

On the Mobilus remote the channels numbers rotate, i.e. when last blind is reached (default 99) and button "up" is pressed again - then next blind channel number is 1. It goes both ways- when channel 1 is selected- the button "down" moves to the last available blind channel- by default it's 99, in pwrozycki setup it's 22, in my setup it's 10.

Moving to the the blind channel that is requested in mqtt message was already fast, but before in case user was on channel 1 and wanted to move to channel 99- button "up" had to be pressed 98 times. Now, in the same scenario- button "down" will be pressed only once.

That way moving to the requested blind will happen even faster.